### PR TITLE
Intégration Cypress pour tests E2E

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -247,6 +247,45 @@ RUN apt-get update && apt-get install -y --no-install-recommends unzip \
 		&& cd \
 		&& apt-get purge -y --auto-remove unzip
 
+#  ██████ ██    ██ ██████  ██████  ███████ ███████ ███████
+# ██       ██  ██  ██   ██ ██   ██ ██      ██      ██
+# ██        ████   ██████  ██████  █████   ███████ ███████
+# ██         ██    ██      ██   ██ ██           ██      ██
+#  ██████    ██    ██      ██   ██ ███████ ███████ ███████
+
+# https://hub.docker.com/u/cypress
+
+# Install Cypress dependencies
+RUN apt-get update && \
+  apt-get install -y \
+    libgbm1 \
+    libgtk2.0-0 \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    xvfb
+
+# Install Cypress globally
+RUN npm install --silent --global --unsafe-perm cypress
+
+# Install Chrome
+ARG CHROME_VERSION
+ENV CHROME_VERSION=$CHROME_VERSION
+RUN wget --no-verbose -O /usr/src/google-chrome-stable_current_amd64.deb "http://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}-1_amd64.deb" && \
+  dpkg -i /usr/src/google-chrome-stable_current_amd64.deb ; \
+  apt-get install -f -y && \
+  rm -f /usr/src/google-chrome-stable_current_amd64.deb
+
+# Install Firefox
+ARG FIREFOX_VERSION
+ENV FIREFOX_VERSION=$FIREFOX_VERSION
+RUN wget --no-verbose -O /tmp/firefox.tar.bz2 \
+  https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && ln -fs /opt/firefox/firefox /usr/bin/firefox
 
 ###### Bonus virtualenv, lxml/docutils and pipenv
 RUN pip install "virtualenv<20.0.0" lxml docutils pipenv

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 IMAGE ?= kozea/python-node-yarn-postgresql
-TAG ?= latest
+TAG ?= cypress
 # BUILD_ARGS :=, additional `docker build` arguments
+
+CHROME_VERSION ?= 86.0.4240.193
+FIREFOX_VERSION ?= 82.0.3
 
 build: Dockerfile
 	docker build \
 		--tag $(IMAGE):$(TAG) \
+		--build-arg CHROME_VERSION=$(CHROME_VERSION) \
+		--build-arg FIREFOX_VERSION=$(FIREFOX_VERSION) \
 		$(BUILD_ARGS) \
 		.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+IMAGE ?= kozea/python-node-yarn-postgresql
+TAG ?= latest
+# BUILD_ARGS :=, additional `docker build` arguments
+
+build: Dockerfile
+	docker build \
+		--tag $(IMAGE):$(TAG) \
+		$(BUILD_ARGS) \
+		.


### PR DESCRIPTION
Les tests du dépôt de démonstration de Cypress et d'hydra passent lancés manuellement.

Le poids de l'image passe par contre de 1,7 Go à 2,9 Go (mais logique vu les nouvelles dépendances ajoutées). 

Pourras-tu me faire un premier retour @cmigazzi ?

Je ferai une PR sur Hydra pour lancer les tests E2E depuis le makefile.